### PR TITLE
outputparser: improve BooleanOutputParser

### DIFF
--- a/outputparser/boolean_parser.go
+++ b/outputparser/boolean_parser.go
@@ -11,15 +11,15 @@ import (
 
 // BooleanParser is an output parser used to parse the output of an LLM as a boolean.
 type BooleanParser struct {
-	TrueStr  string
-	FalseStr string
+	TrueStrings  []string
+	FalseStrings []string
 }
 
 // NewBooleanParser returns a new BooleanParser.
 func NewBooleanParser() BooleanParser {
 	return BooleanParser{
-		TrueStr:  "YES",
-		FalseStr: "NO",
+		TrueStrings:  []string{"YES", "TRUE"},
+		FalseStrings: []string{"NO", "FALSE"},
 	}
 }
 
@@ -33,16 +33,20 @@ func (p BooleanParser) GetFormatInstructions() string {
 
 func (p BooleanParser) parse(text string) (bool, error) {
 	text = normalize(text)
-	booleanStrings := []string{p.TrueStr, p.FalseStr}
+	booleanStrings := append(p.TrueStrings, p.FalseStrings...)
 
-	if !slices.Contains(booleanStrings, text) {
-		return false, ParseError{
-			Text:   text,
-			Reason: fmt.Sprintf("Expected output to be either '%s' or '%s', received %s", p.TrueStr, p.FalseStr, text),
-		}
+	if slices.Contains(p.TrueStrings, text) {
+		return true, nil
 	}
 
-	return text == p.TrueStr, nil
+	if slices.Contains(p.FalseStrings, text) {
+		return false, nil
+	}
+
+	return false, ParseError{
+		Text:   text,
+		Reason: fmt.Sprintf("Expected output to one of %v, received %s", booleanStrings, text),
+	}
 }
 
 func normalize(text string) string {

--- a/outputparser/boolean_parser_test.go
+++ b/outputparser/boolean_parser_test.go
@@ -24,6 +24,7 @@ func TestBooleanParser(t *testing.T) {
 		},
 		{
 			input:    "YESNO",
+			err:      outputparser.ParseError{},
 			expected: false,
 		},
 		{
@@ -31,18 +32,51 @@ func TestBooleanParser(t *testing.T) {
 			err:      outputparser.ParseError{},
 			expected: false,
 		},
+		{
+			input:    "true",
+			expected: true,
+		},
+		{
+			input:    "false",
+			expected: false,
+		},
+		{
+			input:    "True",
+			expected: true,
+		},
+		{
+			input:    "False",
+			expected: false,
+		},
+		{
+			input:    "TRUE",
+			expected: true,
+		},
+		{
+			input:    "FALSE",
+			expected: false,
+		},
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		parser := outputparser.NewBooleanParser()
 
-		actual, err := parser.Parse(tc.input)
-		if tc.err != nil && err == nil {
-			t.Errorf("Expected error %v, got nil", tc.err)
-		}
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
 
-		if actual != tc.expected {
-			t.Errorf("Expected %v, got %v", tc.expected, actual)
-		}
+			result, err := parser.Parse(tc.input)
+			if err != nil && tc.err == nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if err == nil && tc.err != nil {
+				t.Errorf("Expected error %v, got nil", tc.err)
+			}
+
+			if result != tc.expected {
+				t.Errorf("Expected %v, but got %v", tc.expected, result)
+			}
+		})
 	}
 }


### PR DESCRIPTION
The BooleanOutputParser requests the LLM to respond with a boolean, and gives examples such as `true` or `false`. However, it only parsed respones that include YES or NO. This commits adds more values for parsing and changes the tests to fit them.


### PR Checklist

- [ ] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [ ] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [ ] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
