### PR TITLE
outputparser: improve DefinedOutputParser

### DIFF
--- a/outputparser/defined.go
+++ b/outputparser/defined.go
@@ -53,7 +53,7 @@ var _ schema.OutputParser[any] = Defined[any]{}
 
 // GetFormatInstructions returns a string describing the format of the output.
 func (p Defined[T]) GetFormatInstructions() string {
-	const instructions = "Your output should be in JSON, structured according to this TypeScript:\n```typescript\n%s\n```"
+	const instructions = "Your output should be in JSON, structured according to this schema:\n```json\n%s\n```"
 	return fmt.Sprintf(instructions, p.schema)
 }
 


### PR DESCRIPTION
The DefinedOutputParser prompted the LLM with a Typescript schema, but expected a json in response. Now it also requests a jon schema.


### PR Checklist

- [ ] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [ ] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [ ] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
