### PR TITLE
outputparser: allow json to start with ```

### DIFF
--- a/outputparser/defined.go
+++ b/outputparser/defined.go
@@ -62,12 +62,22 @@ func (p Defined[T]) Parse(text string) (T, error) {
 	var target T
 
 	// Removes '```json' and '```' from the start and end of the text.
-	const opening = "```json"
-	const closing = "```"
-	if text[:len(opening)] != opening || text[len(text)-len(closing):] != closing {
-		return target, fmt.Errorf("input text should start with %s and end with %s", opening, closing)
+	const opening1 = "```json"
+	const opening2 = "```"
+	switch {
+	case len(text) >= len(opening1) && text[:len(opening1)] == opening1:
+		text = text[len(opening1):]
+	case len(text) >= len(opening2) && text[:len(opening2)] == opening2:
+		text = text[len(opening2):]
+	default:
+		return target, errors.New("input text should start with '```json' or '```'")
 	}
-	parseableJSON := text[len(opening) : len(text)-len(closing)]
+
+	const closing = "```"
+	if len(text) >= len(closing) && text[len(text)-len(closing):] != closing {
+		return target, fmt.Errorf("input text should end with %s", closing)
+	}
+	parseableJSON := text[:len(text)-len(closing)]
 	if err := json.Unmarshal([]byte(parseableJSON), &target); err != nil {
 		return target, fmt.Errorf("could not parse generated JSON: %w", err)
 	}


### PR DESCRIPTION
Allow the returning schema to start with \```, not just \```json


### PR Checklist

- [ ] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [ ] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [ ] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
