### PR TITLE
outputparser: allow json to start with any prefix

### DIFF
--- a/outputparser/defined.go
+++ b/outputparser/defined.go
@@ -69,16 +69,13 @@ func (p Defined[T]) Parse(text string) (T, error) {
 		text = text[len(opening1):]
 	case len(text) >= len(opening2) && text[:len(opening2)] == opening2:
 		text = text[len(opening2):]
-	default:
-		return target, errors.New("input text should start with '```json' or '```'")
 	}
 
 	const closing = "```"
-	if len(text) >= len(closing) && text[len(text)-len(closing):] != closing {
-		return target, fmt.Errorf("input text should end with %s", closing)
+	if len(text) >= len(closing) && text[len(text)-len(closing):] == closing {
+		text = text[:len(text)-len(closing)]
 	}
-	parseableJSON := text[:len(text)-len(closing)]
-	if err := json.Unmarshal([]byte(parseableJSON), &target); err != nil {
+	if err := json.Unmarshal([]byte(text), &target); err != nil {
 		return target, fmt.Errorf("could not parse generated JSON: %w", err)
 	}
 	return target, nil

--- a/outputparser/defined.go
+++ b/outputparser/defined.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/tmc/langchaingo/llms"
 	"github.com/tmc/langchaingo/schema"
@@ -64,16 +65,19 @@ func (p Defined[T]) Parse(text string) (T, error) {
 	// Removes '```json' and '```' from the start and end of the text.
 	const opening1 = "```json"
 	const opening2 = "```"
-	switch {
-	case len(text) >= len(opening1) && text[:len(opening1)] == opening1:
-		text = text[len(opening1):]
-	case len(text) >= len(opening2) && text[:len(opening2)] == opening2:
-		text = text[len(opening2):]
+
+	opening1Index := strings.Index(text, opening1)
+	opening2Index := strings.Index(text, opening2)
+	if opening1Index != -1 {
+		text = text[opening1Index+len(opening1):]
+	} else if opening2Index != -1 {
+		text = text[opening2Index+len(opening2):]
 	}
 
 	const closing = "```"
-	if len(text) >= len(closing) && text[len(text)-len(closing):] == closing {
-		text = text[:len(text)-len(closing)]
+	closingIndex := strings.Index(text, closing)
+	if closingIndex != -1 {
+		text = text[:closingIndex]
 	}
 	if err := json.Unmarshal([]byte(text), &target); err != nil {
 		return target, fmt.Errorf("could not parse generated JSON: %w", err)

--- a/outputparser/defined.go
+++ b/outputparser/defined.go
@@ -62,23 +62,13 @@ func (p Defined[T]) GetFormatInstructions() string {
 func (p Defined[T]) Parse(text string) (T, error) {
 	var target T
 
-	// Removes '```json' and '```' from the start and end of the text.
-	const opening1 = "```json"
-	const opening2 = "```"
-
-	opening1Index := strings.Index(text, opening1)
-	opening2Index := strings.Index(text, opening2)
-	if opening1Index != -1 {
-		text = text[opening1Index+len(opening1):]
-	} else if opening2Index != -1 {
-		text = text[opening2Index+len(opening2):]
+	startIndex := strings.Index(text, "{")
+	endIndex := strings.LastIndex(text, "}")
+	if startIndex == -1 || endIndex == -1 {
+		return target, fmt.Errorf("could not find start or end of JSON object")
 	}
+	text = text[startIndex : endIndex+1]
 
-	const closing = "```"
-	closingIndex := strings.Index(text, closing)
-	if closingIndex != -1 {
-		text = text[:closingIndex]
-	}
 	if err := json.Unmarshal([]byte(text), &target); err != nil {
 		return target, fmt.Errorf("could not parse generated JSON: %w", err)
 	}

--- a/outputparser/defined_test.go
+++ b/outputparser/defined_test.go
@@ -174,8 +174,23 @@ func getParseTests() map[string]struct {
 				},
 			},
 		},
-		"llm-explanation-and-valid": {
+		"llm-explanation-and-tags": {
 			input: fmt.Sprintf("Sure! Here's the JSON:\n\n```json\n%s\n```\n\nLet me know if you need anything else.", fmt.Sprintf(
+				`{"chapters": [{"title": "%s"}, {"title": "%s"}, {"title": "%s"}]}`, titles[0], titles[1], titles[2],
+			)),
+			wantErr: false,
+			expected: &book{
+				Chapters: []struct {
+					Title string `json:"title" describe:"chapter title"`
+				}{
+					{Title: titles[0]},
+					{Title: titles[1]},
+					{Title: titles[2]},
+				},
+			},
+		},
+		"llm-explanation-and-valid": {
+			input: fmt.Sprintf("Sure! Here's the JSON:\n\n%s\n\nLet me know if you need anything else.", fmt.Sprintf(
 				`{"chapters": [{"title": "%s"}, {"title": "%s"}, {"title": "%s"}]}`, titles[0], titles[1], titles[2],
 			)),
 			wantErr: false,

--- a/outputparser/defined_test.go
+++ b/outputparser/defined_test.go
@@ -174,6 +174,21 @@ func getParseTests() map[string]struct {
 				},
 			},
 		},
+		"llm-explanation-and-valid": {
+			input: fmt.Sprintf("Sure! Here's the JSON:\n\n```json\n%s\n```\n\nLet me know if you need anything else.", fmt.Sprintf(
+				`{"chapters": [{"title": "%s"}, {"title": "%s"}, {"title": "%s"}]}`, titles[0], titles[1], titles[2],
+			)),
+			wantErr: false,
+			expected: &book{
+				Chapters: []struct {
+					Title string `json:"title" describe:"chapter title"`
+				}{
+					{Title: titles[0]},
+					{Title: titles[1]},
+					{Title: titles[2]},
+				},
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
Now the output can start with ```json, ``` or nothing; and end with ``` or nothing.


### PR Checklist

- [ ] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [ ] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [ ] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
